### PR TITLE
.gitignore 에 jpa buddy 플러그인의 설정 파일을 무시하도록 룰 추가

### DIFF
--- a/fastcampus-project-board/.gitignore
+++ b/fastcampus-project-board/.gitignore
@@ -8,6 +8,9 @@
 ### Querydsl
 /src/main/generated
 
+### JPA Buddy
+.jpb/
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml


### PR DESCRIPTION
intellij plugin 중 jpa 작업을 편하게 해주는 jpa buddy 라는 플러그인으로 인해 자동 생성되는 설정 파일이 프로젝트에 포함되지 않도록 파일 무시 규칙을 추가함